### PR TITLE
paths: refuse a home directory marked .production unless explicitly allowed

### DIFF
--- a/tests/test_agentmd_compat.py
+++ b/tests/test_agentmd_compat.py
@@ -150,10 +150,18 @@ class TestChangeTable:
 
 
 class TestWhoami:
-    def test_whoami_reports_the_output_schema_version(self):
-        """An agent has to be able to tell v1 output from v2 without probing."""
+    def test_whoami_reports_the_output_schema_version(self, tlgr_home, monkeypatch):
+        """An agent has to be able to tell v1 output from v2 without probing.
+
+        Runs against the isolated `tlgr_home`: the legacy `whoami` reads the
+        account store, and a test must never open the developer's real
+        `~/.tlgr` (which is now refused when marked as production).
+        """
         from click.testing import CliRunner
 
+        import tlgr.core.config as config
+
+        monkeypatch.setattr(config, "CONFIG_DIR", tlgr_home)
         result = CliRunner().invoke(cli, ["--json", "agent", "whoami"])
         assert result.exit_code == 0, result.output
         assert '"output_schema_version": 2' in result.output

--- a/tests/test_production_home_guard.py
+++ b/tests/test_production_home_guard.py
@@ -1,0 +1,36 @@
+"""A home marked `.production` is refused by development code (see paths.refuse_production_home)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tlgr.core.errors import ConfigurationError
+from tlgr.core.paths import PRODUCTION_MARKER, TlgrPaths, refuse_production_home
+
+
+def test_unmarked_home_is_fine(tmp_path):
+    TlgrPaths(tmp_path)
+    refuse_production_home(tmp_path)
+
+
+def test_marked_home_is_refused_with_a_hint(tmp_path):
+    (tmp_path / PRODUCTION_MARKER).touch()
+    with pytest.raises(ConfigurationError) as excinfo:
+        TlgrPaths(tmp_path)
+    message = str(excinfo.value)
+    assert "TLGR_HOME" in message
+    assert "TLGR_ALLOW_PRODUCTION_HOME" in message
+
+
+def test_explicit_override_allows_the_marked_home(tmp_path, monkeypatch):
+    (tmp_path / PRODUCTION_MARKER).touch()
+    monkeypatch.setenv("TLGR_ALLOW_PRODUCTION_HOME", "1")
+    assert TlgrPaths(tmp_path).base == tmp_path
+
+
+def test_default_base_honours_the_marker_too(tmp_path, monkeypatch):
+    monkeypatch.setenv("TLGR_HOME", str(tmp_path))
+    monkeypatch.delenv("TLGR_ALLOW_PRODUCTION_HOME", raising=False)
+    (tmp_path / PRODUCTION_MARKER).touch()
+    with pytest.raises(ConfigurationError):
+        TlgrPaths()

--- a/tlgr/core/paths.py
+++ b/tlgr/core/paths.py
@@ -26,9 +26,11 @@ from tlgr.core.errors import ConfigurationError, UsageError
 
 __all__ = [
     "ALIAS_RE",
+    "PRODUCTION_MARKER",
     "TlgrPaths",
     "audit_permissions",
     "default_base",
+    "refuse_production_home",
     "validate_alias",
     "write_private",
 ]
@@ -49,6 +51,34 @@ def default_base() -> Path:
     if override:
         return Path(override).expanduser()
     return Path.home() / ".tlgr"
+
+
+#: A home directory carrying this marker belongs to a live deployment.
+PRODUCTION_MARKER = ".production"
+_ALLOW_PRODUCTION_ENV = "TLGR_ALLOW_PRODUCTION_HOME"
+
+
+def refuse_production_home(base: Path) -> None:
+    """Refuse to operate on a home marked as production unless told to.
+
+    A development checkout that resolves to the same `~/.tlgr` as the
+    installed, running tlgr is a live deploy by accident: on 2026-09-03 a dev
+    daemon started from a worktree bound the production socket, held the
+    production session files (``database is locked``) and served a registry
+    without the message routes the running agent needed. `TLGR_HOME` already
+    lets a dev point elsewhere; this makes forgetting to set it fail fast
+    instead of silently taking over. Touch ``<home>/.production`` on the
+    deployment; set ``TLGR_ALLOW_PRODUCTION_HOME=1`` only from the installed
+    tlgr that is meant to run there.
+    """
+    if os.environ.get(_ALLOW_PRODUCTION_ENV, "").strip() == "1":
+        return
+    if (base / PRODUCTION_MARKER).exists():
+        raise ConfigurationError(
+            f"{base} is marked as a production home ({PRODUCTION_MARKER} present). "
+            "Set TLGR_HOME to a separate directory for development, or "
+            f"{_ALLOW_PRODUCTION_ENV}=1 when this really is the deployed tlgr."
+        )
 
 
 def validate_alias(alias: str) -> str:
@@ -99,6 +129,7 @@ class TlgrPaths:
 
     def __init__(self, base: Path | str | None = None) -> None:
         self.base = Path(base) if base is not None else default_base()
+        refuse_production_home(self.base)
 
     # -- top level ---------------------------------------------------------
 


### PR DESCRIPTION
Guard against a development checkout operating on the live `~/.tlgr`: a `.production` marker file in the home makes every `TlgrPaths` construction (daemon start, transport, config) fail fast with the fix in the message; `TLGR_ALLOW_PRODUCTION_HOME=1` is the explicit override for the deployed install. Motivated by a dev daemon from an agent worktree binding the production socket and locking the production session files today. Includes tests.